### PR TITLE
feat(api): added /api/quizzes endpoint to return published quizzes

### DIFF
--- a/src/main/java/com/example/quizzer/quiz/QuizRepository.java
+++ b/src/main/java/com/example/quizzer/quiz/QuizRepository.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
-   List<Quiz> findByTeacherId(Long teacherId);
+    List<Quiz> findByTeacherId(Long teacherId);
+
     List<Quiz> findByTeacherIdAndPublishedTrue(Long teacherId);
+
+    List<Quiz> findByPublishedTrue(); // for ex. 20
+
 }

--- a/src/main/java/com/example/quizzer/quiz/QuizRestController.java
+++ b/src/main/java/com/example/quizzer/quiz/QuizRestController.java
@@ -1,0 +1,19 @@
+package com.example.quizzer.quiz;
+
+import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*") // allow frontend requests from localhost:5173
+public class QuizRestController {
+
+  @Autowired
+  private QuizRepository quizRepository;
+
+  @GetMapping("/quizzes")
+  public List<Quiz> getPublishedQuizzes() {
+    return quizRepository.findByPublishedTrue();
+  }
+}


### PR DESCRIPTION
Added REST endpoint /api/quizzes to return only published quizzes.
Enabled CORS to allow frontend requests from localhost:5173.